### PR TITLE
Handle single line short summary

### DIFF
--- a/docrep/__init__.py
+++ b/docrep/__init__.py
@@ -194,7 +194,7 @@ class DocstringProcessor(object):
         all_sections = self.param_like_sections + self.text_sections
         for section in self.param_like_sections:
             patterns[section] = re.compile(
-                '(?:\s*%s\n\s*%s\n)(?s)(.+?)(?=\n\n\S+|$)' % (
+                '(?:\s*%s\n\s*%s\n)(?s)(.+?)(?=\n\n.+|$)' % (
                     section, '-'*len(section)))
         all_sections_patt = '|'.join(
             '%s\n%s\n' % (s, '-'*len(s)) for s in all_sections)
@@ -253,7 +253,7 @@ class DocstringProcessor(object):
 
     def _get_section(self, s, section):
         try:
-            return self.patterns[section].search(s).group(1).rstrip()
+            return self.patterns[section].search(s).group(1).strip()
         except AttributeError:
             return ''
 

--- a/docrep/__init__.py
+++ b/docrep/__init__.py
@@ -194,7 +194,7 @@ class DocstringProcessor(object):
         all_sections = self.param_like_sections + self.text_sections
         for section in self.param_like_sections:
             patterns[section] = re.compile(
-                '(?<=%s\n%s\n)(?s)(.+?)(?=\n\n\S+|$)' % (
+                '(?:\s*%s\n\s*%s\n)(?s)(.+?)(?=\n\n\S+|$)' % (
                     section, '-'*len(section)))
         all_sections_patt = '|'.join(
             '%s\n%s\n' % (s, '-'*len(s)) for s in all_sections)
@@ -253,7 +253,7 @@ class DocstringProcessor(object):
 
     def _get_section(self, s, section):
         try:
-            return self.patterns[section].search(s).group(0).rstrip()
+            return self.patterns[section].search(s).group(1).rstrip()
         except AttributeError:
             return ''
 

--- a/docrep/__init__.py
+++ b/docrep/__init__.py
@@ -252,12 +252,10 @@ class DocstringProcessor(object):
         if not sections_patt.match(s):
             # remove the summary
             lines = summary_patt.sub('', s, 1).splitlines()
-            print(lines)
             # look for the first line with content
             first = next((i for i, l in enumerate(lines) if l.strip()), 0)
             # dedent the lines
             s = dedents('\n' + '\n'.join(lines[first:]))
-        print(s)
         for section in sections:
             key = '%s.%s' % (base, section.lower().replace(' ', '_'))
             params[key] = self._get_section(s, section)

--- a/docrep/__init__.py
+++ b/docrep/__init__.py
@@ -23,7 +23,7 @@ substitution_pattern = re.compile(
         \((?P<key>(?s).*?)\)# key enclosed in brackets""", re.VERBOSE)
 
 
-summary_patt = re.compile(r'(?s).*?(?=(\n\n)|$)')
+summary_patt = re.compile(r'(?s).*?(?=(\n\s*\n)|$)')
 
 
 def safe_modulo(s, meta, checked='', print_warning=True, stacklevel=2):
@@ -194,7 +194,7 @@ class DocstringProcessor(object):
         all_sections = self.param_like_sections + self.text_sections
         for section in self.param_like_sections:
             patterns[section] = re.compile(
-                '(?:\s*%s\n\s*%s\n)(?s)(.+?)(?=\n\n.+|$)' % (
+                '(?<=%s\n%s\n)(?s)(.+?)(?=\n\n\S+|$)' % (
                     section, '-'*len(section)))
         all_sections_patt = '|'.join(
             '%s\n%s\n' % (s, '-'*len(s)) for s in all_sections)
@@ -246,6 +246,18 @@ class DocstringProcessor(object):
             for saving an entire docstring
         """
         params = self.params
+        sections_patt = re.compile('|'.join(sections) + '(?=\n\s*-)')
+        # if the string does not start with one of the sections, we remove the
+        # summary
+        if not sections_patt.match(s):
+            # remove the summary
+            lines = summary_patt.sub('', s, 1).splitlines()
+            print(lines)
+            # look for the first line with content
+            first = next((i for i, l in enumerate(lines) if l.strip()), 0)
+            # dedent the lines
+            s = dedents('\n' + '\n'.join(lines[first:]))
+        print(s)
         for section in sections:
             key = '%s.%s' % (base, section.lower().replace(' ', '_'))
             params[key] = self._get_section(s, section)
@@ -253,7 +265,7 @@ class DocstringProcessor(object):
 
     def _get_section(self, s, section):
         try:
-            return self.patterns[section].search(s).group(1).strip()
+            return self.patterns[section].search(s).group(0).rstrip()
         except AttributeError:
             return ''
 

--- a/tests/test_docrep.py
+++ b/tests/test_docrep.py
@@ -171,8 +171,15 @@ class TestDocstringProcessor(_BaseTest):
     def tearDown(self):
         del self.ds
 
-    def test_get_sectionsf(self):
+    def test_get_sectionsf(self, indented=False):
         """Test whether the parameter sections are extracted correctly"""
+        if indented:
+            def indent(s):
+                return ' ' * 4 + ('\n' + ' ' * 4).join(s.splitlines())
+        else:
+            def indent(s):
+                return s
+
         self.params_section = ps = simple_param + '\n' + complex_param
         self.other_params_section = ops = (
             simple_multiline_param + '\n' + very_complex_param)
@@ -183,14 +190,14 @@ class TestDocstringProcessor(_BaseTest):
             pass
 
         test.__doc__ = (
-            summary + '\n\n' +
-            random_text + '\n\n' +
-            parameters_header + '\n' + ps + '\n\n' +
-            other_parameters_header + '\n' + ops + '\n\n' +
-            returns_header + '\n' + rs + '\n\n' +
-            examples_header + '\n' + examples + '\n\n' +
-            notes_header + '\n' + notes + '\n\n' +
-            see_also_header + '\n' + see_also)
+            summary + '\n\n' + indent(
+                random_text + '\n\n' +
+                parameters_header + '\n' + ps + '\n\n' +
+                other_parameters_header + '\n' + ops + '\n\n' +
+                returns_header + '\n' + rs + '\n\n' +
+                examples_header + '\n' + examples + '\n\n' +
+                notes_header + '\n' + notes + '\n\n' +
+                see_also_header + '\n' + see_also))
         base = 'test'
 
         decorator = self.ds.get_sectionsf(
@@ -207,6 +214,9 @@ class TestDocstringProcessor(_BaseTest):
         self.assertEqual(ds.params[base + '.notes'], notes)
         self.assertEqual(ds.params[base + '.see_also'], see_also)
         self.assertEqual(ds.params[base + '.references'], '')
+
+    def test_get_sectionsf_indented(self):
+        self.test_get_sectionsf(indented=True)
 
     def test_dedent(self):
         self.test_get_sectionsf()


### PR DESCRIPTION
Handle the case (as in the numpydoc standard) where the short summary is attached to the triple quote. i.e.
    '''Short summary

    longer summary...

    Parameters
    ------------
...
'''
Without this PR, dedent does not remove the spaces at the beginning of Parameters (since lowest number of spaces at line0 is 0) and then the regexp fails.

Don't know if this is the best regexp, but seems to do the job.
