### PR TITLE
Fix part of the docstrings doctests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,11 +54,6 @@ coverage.xml
 docs/_build/
 docs/index.doctree
 
-# test results
-*psyplot_testresults
-tests/envs/cov_psyplot_py*
-tests/envs/psyplot_py*.html
-
 # PyBuilder
 target/
 

--- a/docrep/__init__.py
+++ b/docrep/__init__.py
@@ -65,7 +65,7 @@ def safe_modulo(s, meta, checked='', print_warning=True, stacklevel=2):
     --------
     The effects are demonstrated by this example::
 
-        >>> from psyplot.docstring import safe_modulo
+        >>> from docrep import safe_modulo
         >>> s = "That's %(one)s string %(with)s missing 'with' and %s key"
         >>> s % {'one': 1}
         # raises KeyError because of missing 'with'
@@ -110,7 +110,7 @@ class DocstringProcessor(object):
     --------
     Create docstring processor via::
 
-        >>> from psyplot.docstring import DocstringProcessor
+        >>> from docrep import DocstringProcessor
         >>> d = DocstringProcessor(doc_key='My doc string')
 
     And then use it as a decorator to process the docstring::
@@ -121,7 +121,7 @@ class DocstringProcessor(object):
         ...     pass
 
         >>> print(doc_test.__doc__)
-        That's my doc string
+        That's My doc string
 
     Use the :meth:`get_sectionsf` method to extract Parameter sections (or
     others) form the docstring for later usage (and make sure, that the


### PR DESCRIPTION
It started by wanting to remove the psyplot.docstring occurences but while I was at it I quickly looked at the doctests and fixed the easy one.

I had a quick look, and FYI you still have failures in your doctests. To reproduce:
```
pytest docrep --doctest-modules 
```

I am not sure some of the stuff you are doing is easy to test with doctest (e.g. multi-line expected outputs with blank lines in the middle or expected exceptions) so maybe `# doctest: +SKIP` is the right approach and/or moving some of your doctest code to tests.